### PR TITLE
Fix directory enumeration watcher signal type

### DIFF
--- a/src/directorymonitor.cpp
+++ b/src/directorymonitor.cpp
@@ -9,7 +9,7 @@ DirectoryMonitor::DirectoryMonitor(QObject *parent, QStringList pathsToWatch) : 
     m_scanTimer.setSingleShot(true);
     connect(&m_scanTimer, &QTimer::timeout, this, &DirectoryMonitor::scanPaths);
 
-    connect(&m_pathsEnumeratedWatcher, &QFutureWatcher<int>::finished, this, &DirectoryMonitor::directoriesEnumerated);
+    connect(&m_pathsEnumeratedWatcher, &QFutureWatcher<QStringList>::finished, this, &DirectoryMonitor::directoriesEnumerated);
     auto future = QtConcurrent::run(this, &DirectoryMonitor::enumeratePathsAsync, pathsToWatch);
     m_pathsEnumeratedWatcher.setFuture(future);
 }


### PR DESCRIPTION
## Summary
- Fix DirectoryMonitor constructor to connect to QFutureWatcher<QStringList>::finished

## Testing
- `cmake ..` (fails: missing gstreamer packages before install, then succeeds)
- `cmake --build .` (terminated early after partial build)
- `/tmp/test_dm` (Enumerated paths: (".", "./a", "./a/b"))


------
https://chatgpt.com/codex/tasks/task_e_68952575e5e483309b27fa520b9f91e0