### PR TITLE
Replace QRegExp with QRegularExpression

### DIFF
--- a/src/dlgeditsong.cpp
+++ b/src/dlgeditsong.cpp
@@ -1,7 +1,7 @@
 #include "dlgeditsong.h"
 #include "ui_dlgeditsong.h"
-#include <QRegExpValidator>
-#include <QRegExp>
+#include <QRegularExpressionValidator>
+#include <QRegularExpression>
 
 DlgEditSong::DlgEditSong(QString artist, QString title, QString songId, bool showSongId, bool allowRename, QWidget *parent) :
     QDialog(parent),
@@ -11,9 +11,9 @@ DlgEditSong::DlgEditSong(QString artist, QString title, QString songId, bool sho
     ui->lineEditArtist->setText(artist);
     ui->lineEditTitle->setText(title);
     ui->lineEditSongId->setText(songId);
-    QRegExp exp("[^\\*\\:\\/\\\\]+");
-    exp.setCaseSensitivity(Qt::CaseInsensitive);
-    QRegExpValidator *v = new QRegExpValidator(exp, this);
+    QRegularExpression exp("[^\\*\\:\\/\\\\]+");
+    exp.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
+    QRegularExpressionValidator *v = new QRegularExpressionValidator(exp, this);
     ui->lineEditArtist->setValidator(v);
     ui->lineEditTitle->setValidator(v);
     ui->lineEditSongId->setValidator(v);

--- a/src/dlgsongshoppurchase.cpp
+++ b/src/dlgsongshoppurchase.cpp
@@ -1,6 +1,8 @@
 #include "dlgsongshoppurchase.h"
 
 #include <utility>
+#include <QRegularExpressionValidator>
+#include <QRegularExpression>
 #include "ui_dlgsongshoppurchase.h"
 #include "dlgsetpassword.h"
 #include "dlgpassword.h"
@@ -14,10 +16,10 @@ DlgSongShopPurchase::DlgSongShopPurchase(std::shared_ptr<SongShop> songShop, QWi
 {
     setupDone = false;
     ui->setupUi(this);
-    ui->lineEditCCN->setValidator(new QRegExpValidator(QRegExp("[0-9]*"), this));
-    ui->lineEditCCM->setValidator(new QRegExpValidator(QRegExp("[0-9]*"), this));
-    ui->lineEditCCY->setValidator(new QRegExpValidator(QRegExp("[0-9]*"), this));
-    ui->lineEditCCV->setValidator(new QRegExpValidator(QRegExp("[0-9]*"), this));
+    ui->lineEditCCN->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9]*"), this));
+    ui->lineEditCCM->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9]*"), this));
+    ui->lineEditCCY->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9]*"), this));
+    ui->lineEditCCV->setValidator(new QRegularExpressionValidator(QRegularExpression("[0-9]*"), this));
     knLoginTest = false;
     ui->cbxSaveAccount->setChecked(m_settings.saveKNAccount());
     ui->cbxSaveCard->setChecked(m_settings.saveCC());

--- a/src/okarchive.cpp
+++ b/src/okarchive.cpp
@@ -23,6 +23,7 @@
 #include <QFile>
 #include <QBuffer>
 #include <QTemporaryDir>
+#include <QRegularExpression>
 #ifdef Q_OS_WIN
 #include <io.h>
 #else
@@ -322,9 +323,9 @@ zipEntries OkArchive::getZipContents()
     }
     m_logger->trace("{} Infozip output: \n{}",m_loggingPrefix, output);
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    QStringList data = output.split(QRegExp("[\r\n]"),QString::SkipEmptyParts);
+    QStringList data = output.split(QRegularExpression("[\r\n]"),QString::SkipEmptyParts);
 #else
-    QStringList data = output.split(QRegExp("[\r\n]"),Qt::SkipEmptyParts);
+    QStringList data = output.split(QRegularExpression("[\r\n]"),Qt::SkipEmptyParts);
 #endif
     int fnStart = 0;
     int listStart = 0;


### PR DESCRIPTION
## Summary
- Replace deprecated `QRegExp` and `QRegExpValidator` usages with `QRegularExpression` and `QRegularExpressionValidator`
- Update archive output splitting to use `QRegularExpression`
- Set up modern regex-based validators for song edit and purchase dialogs

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689528dc2218833097674221d37f6781