### PR TITLE
Replace QDesktopWidget with QGuiApplication/QScreen

### DIFF
--- a/src/dlgcdg.cpp
+++ b/src/dlgcdg.cpp
@@ -20,7 +20,7 @@
 
 #include "dlgcdg.h"
 #include "ui_dlgcdg.h"
-#include <QDesktopWidget>
+#include <QGuiApplication>
 #include <QSvgRenderer>
 #include <QPainter>
 #include <QDir>
@@ -152,8 +152,10 @@ void DlgCdg::mouseDoubleClickEvent([[maybe_unused]]QMouseEvent *e)
     cdgOffsetsChanged();
     m_settings.setCdgWindowFullscreen(m_fullScreen);
     m_settings.saveWindowState(this);
-    QDesktopWidget widget;
-    m_settings.setCdgWindowFullscreenMonitor(widget.screenNumber(this));
+    auto screen = QGuiApplication::screenAt(this->geometry().center());
+    if (screen) {
+        m_settings.setCdgWindowFullscreenMonitor(QGuiApplication::screens().indexOf(screen));
+    }
 }
 
 QFileInfoList DlgCdg::getSlideShowImages()
@@ -333,8 +335,10 @@ void DlgCdg::btnToggleFullscreenClicked()
         showNormal();
     m_settings.setCdgWindowFullscreen(m_fullScreen);
     m_settings.saveWindowState(this);
-    QDesktopWidget widget;
-    m_settings.setCdgWindowFullscreenMonitor(widget.screenNumber(this));
+    auto screen = QGuiApplication::screenAt(this->geometry().center());
+    if (screen) {
+        m_settings.setCdgWindowFullscreenMonitor(QGuiApplication::screens().indexOf(screen));
+    }
     cdgOffsetsChanged();
 }
 

--- a/src/dlgsettings.cpp
+++ b/src/dlgsettings.cpp
@@ -21,7 +21,6 @@
 #include "dlgsettings.h"
 #include "ui_dlgsettings.h"
 #include <QGuiApplication>
-#include <QDesktopWidget>
 #include <QFontDialog>
 #include <QColorDialog>
 #include <QFileDialog>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -22,7 +22,8 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include <QMessageBox>
-#include <QDesktopWidget>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QMenu>
 #include <QInputDialog>
 #include <QFileDialog>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -21,7 +21,8 @@
 #include "settings.h"
 #include <QCoreApplication>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QStandardPaths>
 #include <QCryptographicHash>
 #include <QDataStream>


### PR DESCRIPTION
## Summary
- refactor screen utilities to use QGuiApplication and QScreen
- remove outdated QDesktopWidget usage

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*


------
https://chatgpt.com/codex/tasks/task_e_68952c50bfe483308caffc828854ab7c