### PR TITLE
refactor: remove macro-based signal-slot connections

### DIFF
--- a/src/softwarerendervideosink.cpp
+++ b/src/softwarerendervideosink.cpp
@@ -35,7 +35,8 @@ SoftwareRenderVideoSink::SoftwareRenderVideoSink(QWidget *surface)
 
     m_surface->installEventFilter(this);
 
-    connect(this, SIGNAL(newFrameAvailable()), m_surface, SLOT(update()), Qt::QueuedConnection);
+    connect(this, &SoftwareRenderVideoSink::newFrameAvailable, m_surface,
+            QOverload<>::of(&QWidget::update), Qt::QueuedConnection);
 }
 
 SoftwareRenderVideoSink::~SoftwareRenderVideoSink()

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -50,7 +50,7 @@ if (m_settings.updatesBranch() == 0)
     channel = "stable";
 else
     channel = "unstable";
-//    connect(manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(onNetworkReply(QNetworkReply*)));
+//    connect(manager, &QNetworkAccessManager::finished, this, &UpdateChecker::onNetworkReply);
 }
 
 void UpdateChecker::checkForUpdates()


### PR DESCRIPTION
## Summary
- Replace macro-based signal-slot connect with function-pointer syntax in SoftwareRenderVideoSink
- Update leftover comment in UpdateChecker to show function-pointer signal-slot syntax

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" with names: Qt5Config.cmake, qt5-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68952c54932c8330a7b6490657403155