### PR TITLE
Add ThemeManager for centralized theme handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,7 @@ set(SOURCE_FILES
         src/dlgsongshoppurchase.cpp
         src/dlgsetpassword.cpp
         src/dlgpassword.cpp
+        src/thememanager.cpp
         src/dlgpurchaseprogress.cpp
         src/karaokefileinfo.cpp
         src/karaokefilepatternresolver.cpp

--- a/src/dlgaddsong.cpp
+++ b/src/dlgaddsong.cpp
@@ -1,12 +1,16 @@
 #include "dlgaddsong.h"
 #include "ui_dlgaddsong.h"
 #include <QMessageBox>
+#include "thememanager.h"
 
 
 DlgAddSong::DlgAddSong(TableModelRotation &rotationModel, TableModelQueueSongs &queueModel, int songId, QWidget *parent) :
     QDialog(parent), ui(new Ui::DlgAddSong), m_rotModel(rotationModel), m_queueModel(queueModel), m_songId(songId)
 {
     ui->setupUi(this);
+    QString thm = ThemeManager::instance().iconPath();
+    ui->pushButtonKeyDown->setIcon(QIcon(thm + "actions/22/downindicator.svg"));
+    ui->pushButtonKeyUp->setIcon(QIcon(thm + "actions/22/upindicator.svg"));
     m_rButtons.addButton(ui->radioButtonAddSinger);
     m_rButtons.setId(ui->radioButtonAddSinger, 0);
     m_rButtons.addButton(ui->radioButtonAddToExistingSinger);

--- a/src/dlgaddsong.ui
+++ b/src/dlgaddsong.ui
@@ -248,10 +248,6 @@
        <property name="text">
         <string/>
        </property>
-       <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/theme/Icons/okjbreeze-dark/actions/22/downindicator.svg</normaloff>:/theme/Icons/okjbreeze-dark/actions/22/downindicator.svg</iconset>
-       </property>
        <property name="iconSize">
         <size>
          <width>26</width>
@@ -286,10 +282,6 @@
        </property>
        <property name="text">
         <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/theme/Icons/okjbreeze-dark/actions/22/upindicator.svg</normaloff>:/theme/Icons/okjbreeze-dark/actions/22/upindicator.svg</iconset>
        </property>
        <property name="iconSize">
         <size>

--- a/src/dlgrequests.cpp
+++ b/src/dlgrequests.cpp
@@ -27,6 +27,7 @@
 #include <QProgressDialog>
 #include "src/models/tableviewtooltipfilter.h"
 #include "dlgvideopreview.h"
+#include "thememanager.h"
 
 #include <spdlog/sinks/basic_file_sink.h>
 
@@ -160,7 +161,7 @@ void DlgRequests::rotationChanged() {
 }
 
 void DlgRequests::updateIcons() {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+    QString thm = ThemeManager::instance().iconPath();
     ui->buttonRefresh->setIcon(QIcon(thm + "actions/22/view-refresh.svg"));
     ui->pushButtonClearReqs->setIcon(QIcon(thm + "actions/22/edit-clear-all.svg"));
     ui->pushButtonSearch->setIcon(QIcon(thm + "actions/22/edit-find.svg"));

--- a/src/dlgsettings.cpp
+++ b/src/dlgsettings.cpp
@@ -191,9 +191,9 @@ DlgSettings::DlgSettings(MediaBackend &AudioBackend, MediaBackend &BmAudioBacken
         ui->comboBoxCodec->setCurrentIndex(ui->comboBoxCodec->findText(m_settings.recordingCodec()));
     ui->comboBoxUpdateBranch->addItem("Stable");
     ui->comboBoxUpdateBranch->addItem("Development");
-    ui->cbxTheme->addItem("OS Native");
-    ui->cbxTheme->addItem("Fusion Dark");
-    ui->cbxTheme->addItem("Fusion Light");
+    ui->cbxTheme->addItem("System");
+    ui->cbxTheme->addItem("Dark");
+    ui->cbxTheme->addItem("Light");
     ui->cbxTheme->setCurrentIndex(m_settings.theme());
     ui->lineEditOutputDir->setText(m_settings.recordingOutputDir());
     ui->cbxTickerShowRotationInfo->setChecked(m_settings.tickerShowRotationInfo());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@
 #include "idledetect.h"
 #include "runguard/runguard.h"
 #include "okjversion.h"
+#include "thememanager.h"
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/async_logger.h>
@@ -169,37 +170,7 @@ int main(int argc, char *argv[]) {
     a.installEventFilter(filter);
     qputenv("GST_DEBUG", "*:3");
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-    if (settings.theme() == 1) {
-        QPalette palette;
-        QApplication::setStyle(QStyleFactory::create("Fusion"));
-        palette.setColor(QPalette::Window, QColor(53, 53, 53));
-        palette.setColor(QPalette::WindowText, Qt::white);
-        palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));
-        palette.setColor(QPalette::Base, QColor(42, 42, 42));
-        palette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
-        palette.setColor(QPalette::ToolTipBase, Qt::white);
-        palette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
-        palette.setColor(QPalette::Text, Qt::white);
-        palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
-        palette.setColor(QPalette::Dark, QColor(35, 35, 35));
-        palette.setColor(QPalette::Shadow, QColor(20, 20, 20));
-        palette.setColor(QPalette::Button, QColor(53, 53, 53));
-        palette.setColor(QPalette::ButtonText, Qt::white);
-        palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127));
-        palette.setColor(QPalette::BrightText, Qt::red);
-        palette.setColor(QPalette::Link, QColor(42, 130, 218));
-        palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
-        palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
-        palette.setColor(QPalette::HighlightedText, Qt::white);
-        palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127));
-        QApplication::setPalette(palette);
-    } else if (settings.theme() == 2) {
-        QApplication::setStyle(QStyleFactory::create("Fusion"));
-    }
-//    else
-//    {
-//
-//    }
+    ThemeManager::instance().initialize(&settings);
     QApplication::setFont(settings.applicationFont(), "QWidget");
     QApplication::setFont(settings.applicationFont(), "QMenu");
     QApplication::setFont(settings.applicationFont(), "QAction");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -42,6 +42,7 @@
 #include <taglib.h>
 #include <miniz/miniz.h>
 #include "okjtypes.h"
+#include "thememanager.h"
 
 #ifdef _MSC_VER
 #define NOMINMAX
@@ -88,7 +89,7 @@ void MainWindow::refreshSfxButtons() {
 }
 
 void MainWindow::updateIcons() {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+    QString thm = ThemeManager::instance().iconPath();
     ui->buttonClearRotation->setIcon(QIcon(thm + "actions/22/edit-clear-all.svg"));
     ui->buttonAddSinger->setIcon(QIcon(thm + "actions/22/list-add-user.svg"));
     ui->buttonRegulars->setIcon(QIcon(thm + "actions/22/user-others.svg"));
@@ -728,7 +729,7 @@ MainWindow::MainWindow(QWidget *parent) :
 }
 
 void MainWindow::loadSettings() {
-    if (m_settings.theme() != 0) {
+    if (ThemeManager::instance().currentTheme() != ThemeManager::System) {
         ui->pushButtonIncomingRequests->setStyleSheet("");
         update();
     }
@@ -2653,9 +2654,9 @@ void MainWindow::timerButtonFlashTimeout() {
 
     if (requestsDialog->numRequests() > 0) {
         static bool flashed = false;
-        if (m_settings.theme() != 0) {
+        if (ThemeManager::instance().currentTheme() != ThemeManager::System) {
             auto normal = this->palette().button().color();
-            auto blink = QColor("yellow");
+            auto blink = ThemeManager::instance().highlightColor();
             auto blinkTxt = QColor("black");
             auto normalTxt = this->palette().buttonText().color();
             auto palette = QPalette(ui->pushButtonIncomingRequests->palette());
@@ -2673,7 +2674,7 @@ void MainWindow::timerButtonFlashTimeout() {
         }
         update();
     } else if (ui->pushButtonIncomingRequests->text() != "Requests") {
-        if (m_settings.theme() != 0) {
+        if (ThemeManager::instance().currentTheme() != ThemeManager::System) {
             ui->pushButtonIncomingRequests->setPalette(this->palette());
             ui->pushButtonIncomingRequests->setText("Requests");
         } else {

--- a/src/models/tablemodelhistorysingers.cpp
+++ b/src/models/tablemodelhistorysingers.cpp
@@ -5,6 +5,7 @@
 #include <QSqlError>
 #include <QPainter>
 #include <QSvgRenderer>
+#include "thememanager.h"
 
 
 TableModelHistorySingers::TableModelHistorySingers(QObject *parent)
@@ -190,7 +191,7 @@ okj::HistorySinger TableModelHistorySingers::getSinger(const int historySingerId
 
 void ItemDelegateHistorySingers::resizeIconsForFont(const QFont& font)
 {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+    QString thm = ThemeManager::instance().iconPath();
     m_curFontHeight = QFontMetrics(font).height();
     m_iconDelete = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
     m_iconLoadReg = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);

--- a/src/models/tablemodelkaraokesongs.cpp
+++ b/src/models/tablemodelkaraokesongs.cpp
@@ -9,6 +9,7 @@
 #include <QDirIterator>
 #include <QSvgRenderer>
 #include <QMimeData>
+#include "thememanager.h"
 #include <array>
 
 std::ostream & operator<<(std::ostream& os, const QString& s);
@@ -331,7 +332,7 @@ void TableModelKaraokeSongs::resizeIconsForFont(const QFont &font) {
     m_headerFont.setBold(true);
     m_itemFontMetrics = QFontMetrics(m_itemFont);
     m_itemHeight = m_itemFontMetrics.height() + 6;
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+    QString thm = ThemeManager::instance().iconPath();
     m_curFontHeight = QFontMetrics(font).height();
     m_iconVid = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
     m_iconZip = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);

--- a/src/models/tablemodelplaylistsongs.cpp
+++ b/src/models/tablemodelplaylistsongs.cpp
@@ -10,6 +10,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QSvgRenderer>
+#include "thememanager.h"
 
 
 TableModelPlaylistSongs::TableModelPlaylistSongs(TableModelBreakSongs &breakSongsModel, QObject *parent)
@@ -64,7 +65,7 @@ QVariant TableModelPlaylistSongs::data(const QModelIndex &index, int role) const
     }
     if (role == Qt::BackgroundRole) {
         if (m_songs.at(index.row()).id == m_playingPlSongId && m_playingPlaylist == m_curPlaylistId)
-            return (m_settings.theme() == 1) ? QColor(180, 180, 0) : QColor("yellow");
+            return ThemeManager::instance().highlightColor();
         return {};
     }
     if (role == Qt::DisplayRole) {
@@ -269,7 +270,7 @@ int TableModelPlaylistSongs::getSongPositionById(const int plSongId) const {
 }
 
 void ItemDelegatePlaylistSongs::resizeIconsForFont(const QFont &font) {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+    QString thm = ThemeManager::instance().iconPath();
     m_curFontHeight = QFontMetrics(font).height();
     m_iconDelete = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
     m_iconPlaying = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);

--- a/src/models/tablemodelqueuesongs.cpp
+++ b/src/models/tablemodelqueuesongs.cpp
@@ -9,6 +9,7 @@
 #include <QUrl>
 #include <QSvgRenderer>
 #include <spdlog/fmt/ostr.h>
+#include "thememanager.h"
 
 std::ostream & operator<<(std::ostream& os, const QString& s);
 
@@ -565,7 +566,7 @@ QSize TableModelQueueSongs::getColumnSizeHint(int section) const {
 }
 
 void ItemDelegateQueueSongs::resizeIconsForFont(const QFont &font) {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+    QString thm = ThemeManager::instance().iconPath();
     m_curFontHeight = QFontMetrics(font).height();
     m_iconDelete = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
     m_iconDelete.fill(Qt::transparent);

--- a/src/models/tablemodelrequests.cpp
+++ b/src/models/tablemodelrequests.cpp
@@ -20,6 +20,7 @@
 
 #include "tablemodelrequests.h"
 #include <QDateTime>
+#include "thememanager.h"
 
 
 TableModelRequests::TableModelRequests(OKJSongbookAPI &songbookAPI, QObject *parent) :
@@ -27,7 +28,7 @@ TableModelRequests::TableModelRequests(OKJSongbookAPI &songbookAPI, QObject *par
         songbookApi(songbookAPI) {
     m_logger = spdlog::get("logger");
     connect(&songbookApi, &OKJSongbookAPI::requestsChanged, this, &TableModelRequests::requestsChanged);
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+    QString thm = ThemeManager::instance().iconPath();
     delete16 = QIcon(thm + "actions/16/edit-delete.svg");
     delete22 = QIcon(thm + "actions/22/edit-delete.svg");
 }

--- a/src/models/tablemodelrotation.cpp
+++ b/src/models/tablemodelrotation.cpp
@@ -28,6 +28,7 @@
 #include <QJsonDocument>
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
+#include "thememanager.h"
 #include <chrono>
 
 std::ostream& operator<<(std::ostream& os, const QString& s);
@@ -110,7 +111,7 @@ QVariant TableModelRotation::data(const QModelIndex &index, int role) const {
 QVariant TableModelRotation::getBackgroundRole(const QModelIndex &index) const {
     if (m_singers.at(index.row()).id == m_currentSingerId) {
         if (index.column() > 0)
-            return (m_settings.theme() == 1) ? QColor(180, 180, 0) : QColor("yellow");
+            return ThemeManager::instance().highlightColor();
     } else if (index.column() == COL_NAME) {
         const auto &singer = m_singers.at(index.row());
         if (singer.id == m_rotationTopSingerId && m_settings.rotationAltSortOrder())
@@ -599,7 +600,7 @@ void TableModelRotation::resizeIconsForFont(const QFont &font) {
 }
 
 void ItemDelegateRotation::resizeIconsForFont(const QFont &font) {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+    QString thm = ThemeManager::instance().iconPath();
     m_curFontHeight = QFontMetrics(font).height();
     m_iconDelete = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
     m_iconCurSinger = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1635,7 +1635,7 @@ int Settings::updatesBranch()
 
 int Settings::theme() const
 {
-    return settings->value("theme", 1).toInt();
+    return settings->value("theme", 0).toInt();
 }
 
 const QPoint Settings::durationPosition()

--- a/src/thememanager.cpp
+++ b/src/thememanager.cpp
@@ -1,0 +1,79 @@
+#include "thememanager.h"
+#include "settings.h"
+
+#include <QApplication>
+#include <QGuiApplication>
+#include <QStyleFactory>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#include <QColorScheme>
+#endif
+#include <QIcon>
+
+ThemeManager::ThemeManager(QObject *parent) : QObject(parent) {}
+
+ThemeManager &ThemeManager::instance() {
+    static ThemeManager inst;
+    return inst;
+}
+
+void ThemeManager::initialize(Settings *settings) {
+    m_settings = settings;
+    detectSystemTheme();
+    Theme pref = System;
+    if (m_settings)
+        pref = static_cast<Theme>(m_settings->theme());
+    if (pref == System) {
+        // m_currentTheme already set by detection
+    } else {
+        m_currentTheme = (pref == Dark) ? Dark : Light;
+    }
+
+    QPalette pal;
+    if (m_currentTheme == Dark) {
+        QApplication::setStyle(QStyleFactory::create("Fusion"));
+        pal.setColor(QPalette::Window, QColor(53,53,53));
+        pal.setColor(QPalette::WindowText, Qt::white);
+        pal.setColor(QPalette::Base, QColor(42,42,42));
+        pal.setColor(QPalette::AlternateBase, QColor(66,66,66));
+        pal.setColor(QPalette::ToolTipBase, Qt::white);
+        pal.setColor(QPalette::ToolTipText, QColor(53,53,53));
+        pal.setColor(QPalette::Text, Qt::white);
+        pal.setColor(QPalette::Button, QColor(53,53,53));
+        pal.setColor(QPalette::ButtonText, Qt::white);
+        pal.setColor(QPalette::BrightText, Qt::red);
+        pal.setColor(QPalette::Link, QColor(42,130,218));
+        pal.setColor(QPalette::Highlight, QColor(42,130,218));
+        pal.setColor(QPalette::HighlightedText, Qt::white);
+    } else {
+        pal = QApplication::palette();
+    }
+    QApplication::setPalette(pal);
+    QIcon::setThemeSearchPaths({":/theme/Icons"});
+    QIcon::setThemeName(m_currentTheme == Dark ? "okjbreeze-dark" : "okjbreeze");
+}
+
+void ThemeManager::detectSystemTheme() {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    auto scheme = QColorScheme::systemColorScheme();
+    m_currentTheme = (scheme == QColorScheme::Dark) ? Dark : Light;
+#else
+    QColor bg = QGuiApplication::palette().color(QPalette::Window);
+    m_currentTheme = (bg.lightness() < 128) ? Dark : Light;
+#endif
+}
+
+ThemeManager::Theme ThemeManager::currentTheme() const {
+    return m_currentTheme;
+}
+
+QString ThemeManager::iconPath() const {
+    return (m_currentTheme == Dark) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
+}
+
+QPalette ThemeManager::palette() const {
+    return QApplication::palette();
+}
+
+QColor ThemeManager::highlightColor() const {
+    return (m_currentTheme == Dark) ? QColor(180,180,0) : QColor("yellow");
+}

--- a/src/thememanager.h
+++ b/src/thememanager.h
@@ -1,0 +1,33 @@
+#ifndef THEMEMANAGER_H
+#define THEMEMANAGER_H
+
+#include <QObject>
+#include <QPalette>
+#include <QColor>
+
+class Settings;
+
+class ThemeManager : public QObject
+{
+    Q_OBJECT
+public:
+    enum Theme { System = 0, Dark, Light };
+
+    static ThemeManager &instance();
+
+    void initialize(Settings *settings);
+    Theme currentTheme() const;
+    QString iconPath() const;
+    QPalette palette() const;
+    QColor highlightColor() const;
+    bool isDark() const { return m_currentTheme == Dark; }
+
+private:
+    explicit ThemeManager(QObject *parent = nullptr);
+    void detectSystemTheme();
+
+    Settings *m_settings{nullptr};
+    Theme m_currentTheme{Light};
+};
+
+#endif // THEMEMANAGER_H


### PR DESCRIPTION
## Summary
- Introduce `ThemeManager` to provide palette, icon path, and highlight colors for dark and light modes, with OS auto-detection.
- Persist theme preference in Settings and expose selection in the Settings dialog.
- Update main window, dialogs, models, and UI files to fetch icons and colors from `ThemeManager` instead of hard-coded values.

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*


------
https://chatgpt.com/codex/tasks/task_e_68952d80257883308957ab41ec69907e