### PR TITLE
Use theme-based icons with SVG fallbacks

### DIFF
--- a/src/dlgaddsong.ui
+++ b/src/dlgaddsong.ui
@@ -249,8 +249,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/theme/Icons/okjbreeze-dark/actions/22/downindicator.svg</normaloff>:/theme/Icons/okjbreeze-dark/actions/22/downindicator.svg</iconset>
+        <iconset theme="downindicator"/>
        </property>
        <property name="iconSize">
         <size>
@@ -288,8 +287,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/theme/Icons/okjbreeze-dark/actions/22/upindicator.svg</normaloff>:/theme/Icons/okjbreeze-dark/actions/22/upindicator.svg</iconset>
+        <iconset theme="upindicator"/>
        </property>
        <property name="iconSize">
         <size>

--- a/src/dlgrequests.cpp
+++ b/src/dlgrequests.cpp
@@ -23,6 +23,7 @@
 #include <QDesktopServices>
 #include <QMenu>
 #include <QMessageBox>
+#include <QIcon>
 #include "okjsongbookapi.h"
 #include <QProgressDialog>
 #include "src/models/tableviewtooltipfilter.h"
@@ -160,11 +161,10 @@ void DlgRequests::rotationChanged() {
 }
 
 void DlgRequests::updateIcons() {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
-    ui->buttonRefresh->setIcon(QIcon(thm + "actions/22/view-refresh.svg"));
-    ui->pushButtonClearReqs->setIcon(QIcon(thm + "actions/22/edit-clear-all.svg"));
-    ui->pushButtonSearch->setIcon(QIcon(thm + "actions/22/edit-find.svg"));
-    ui->pushButtonWebSearch->setIcon(QIcon(thm + "apps/48/internet-web-browser.svg"));
+    ui->buttonRefresh->setIcon(QIcon::fromTheme("view-refresh"));
+    ui->pushButtonClearReqs->setIcon(QIcon::fromTheme("edit-clear-all"));
+    ui->pushButtonSearch->setIcon(QIcon::fromTheme("edit-find"));
+    ui->pushButtonWebSearch->setIcon(QIcon::fromTheme("internet-web-browser"));
 }
 
 void DlgRequests::on_pushButtonClose_clicked() {

--- a/src/dlgsettings.cpp
+++ b/src/dlgsettings.cpp
@@ -28,6 +28,7 @@
 #include <QStandardPaths>
 #include <QMessageBox>
 #include <QSqlQuery>
+#include <QIcon>
 #include <QtSql>
 #include <QXmlStreamWriter>
 #include <QNetworkReply>
@@ -403,7 +404,7 @@ void DlgSettings::setupHotkeysForm() {
         auto sequenceEdit = new QKeySequenceEdit(this);
         sequenceEdit->setObjectName(shortcut.sequenceName);
         sequenceEdit->setKeySequence(m_settings.loadShortcutKeySequence(shortcut.sequenceName));
-        clearButton->setIcon(QIcon(":/theme/Icons/okjbreeze-dark/actions/22/edit-clear.svg"));
+        clearButton->setIcon(QIcon::fromTheme("edit-clear"));
         connect(sequenceEdit, &QKeySequenceEdit::keySequenceChanged, this, &DlgSettings::keySequenceEditChanged);
         connect(clearButton, &QPushButton::pressed, sequenceEdit, &QKeySequenceEdit::clear);
         QHBoxLayout *layout = new QHBoxLayout();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include <QSplashScreen>
 #include <QStringList>
 #include <QMessageBox>
+#include <QIcon>
 #include "settings.h"
 #include "idledetect.h"
 #include "runguard/runguard.h"
@@ -152,6 +153,20 @@ int main(int argc, char *argv[]) {
     //QLoggingCategory::setFilterRules("*.debug=true");
     qInstallMessageHandler(myMessageOutput);
     QApplication a(argc, argv);
+    QIcon::setFallbackSearchPaths({
+        ":/theme/Icons/okjbreeze/actions/16",
+        ":/theme/Icons/okjbreeze/actions/22",
+        ":/theme/Icons/okjbreeze/actions/32",
+        ":/theme/Icons/okjbreeze/apps/48",
+        ":/theme/Icons/okjbreeze/status/16",
+        ":/theme/Icons/okjbreeze/mimetypes/22",
+        ":/theme/Icons/okjbreeze-dark/actions/16",
+        ":/theme/Icons/okjbreeze-dark/actions/22",
+        ":/theme/Icons/okjbreeze-dark/actions/32",
+        ":/theme/Icons/okjbreeze-dark/apps/48",
+        ":/theme/Icons/okjbreeze-dark/status/16",
+        ":/theme/Icons/okjbreeze-dark/mimetypes/22"
+    });
 
 #ifdef MAC_OVERRIDE_GST
     // This points GStreamer paths to the framework contained in the app bundle.  Not needed on brew installs.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -28,6 +28,8 @@
 #include <QFileDialog>
 #include <QImageReader>
 #include <QDesktopServices>
+#include <QIcon>
+#include <QSize>
 #include "mzarchive.h"
 #include "tagreader.h"
 #include "dlgeditsong.h"
@@ -88,36 +90,35 @@ void MainWindow::refreshSfxButtons() {
 }
 
 void MainWindow::updateIcons() {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
-    ui->buttonClearRotation->setIcon(QIcon(thm + "actions/22/edit-clear-all.svg"));
-    ui->buttonAddSinger->setIcon(QIcon(thm + "actions/22/list-add-user.svg"));
-    ui->buttonRegulars->setIcon(QIcon(thm + "actions/22/user-others.svg"));
-    ui->btnRotTop->setIcon(QIcon(thm + "actions/22/go-top.svg"));
-    ui->btnRotUp->setIcon(QIcon(thm + "actions/22/go-up.svg"));
-    ui->btnRotBottom->setIcon(QIcon(thm + "actions/22/go-bottom.svg"));
-    ui->btnRotDown->setIcon(QIcon(thm + "actions/22/go-down.svg"));
-    ui->pushButton->setIcon(QIcon(thm + "actions/22/edit-find.svg"));
-    ui->buttonClearQueue->setIcon(QIcon(thm + "actions/22/edit-clear-all.svg"));
-    ui->btnQTop->setIcon(QIcon(thm + "actions/22/go-top.svg"));
-    ui->btnQUp->setIcon(QIcon(thm + "actions/22/go-up.svg"));
-    ui->btnQBottom->setIcon(QIcon(thm + "actions/22/go-bottom.svg"));
-    ui->btnQDown->setIcon(QIcon(thm + "actions/22/go-down.svg"));
-    ui->buttonPause->setIcon(QIcon(thm + "actions/22/media-playback-pause.svg"));
-    ui->buttonStop->setIcon(QIcon(thm + "actions/22/media-playback-stop.svg"));
-    ui->labelVolume->setPixmap(QPixmap(thm + "actions/16/player-volume.svg"));
-    ui->pushButtonTempoDn->setIcon(QIcon(thm + "actions/22/downindicator.svg"));
-    ui->pushButtonTempoUp->setIcon(QIcon(thm + "actions/22/upindicator.svg"));
-    ui->pushButtonKeyDn->setIcon(QIcon(thm + "actions/22/downindicator.svg"));
-    ui->pushButtonKeyUp->setIcon(QIcon(thm + "actions/22/upindicator.svg"));
-    ui->btnSfxStop->setIcon(QIcon(thm + "actions/22/media-playback-stop.svg"));
-    ui->buttonBmPause->setIcon(QIcon(thm + "actions/22/media-playback-pause.svg"));
-    ui->buttonBmStop->setIcon(QIcon(thm + "actions/22/media-playback-stop.svg"));
-    ui->btnPlTop->setIcon(QIcon(thm + "actions/22/go-top.svg"));
-    ui->btnPlUp->setIcon(QIcon(thm + "actions/22/go-up.svg"));
-    ui->btnPlBottom->setIcon(QIcon(thm + "actions/22/go-bottom.svg"));
-    ui->btnPlDown->setIcon(QIcon(thm + "actions/22/go-down.svg"));
-    ui->labelVolumeBm->setPixmap(QPixmap(thm + "actions/16/player-volume.svg"));
-    ui->buttonBmSearch->setIcon(QIcon(thm + "actions/22/edit-find.svg"));
+    ui->buttonClearRotation->setIcon(QIcon::fromTheme("edit-clear-all"));
+    ui->buttonAddSinger->setIcon(QIcon::fromTheme("list-add-user"));
+    ui->buttonRegulars->setIcon(QIcon::fromTheme("user-others"));
+    ui->btnRotTop->setIcon(QIcon::fromTheme("go-top"));
+    ui->btnRotUp->setIcon(QIcon::fromTheme("go-up"));
+    ui->btnRotBottom->setIcon(QIcon::fromTheme("go-bottom"));
+    ui->btnRotDown->setIcon(QIcon::fromTheme("go-down"));
+    ui->pushButton->setIcon(QIcon::fromTheme("edit-find"));
+    ui->buttonClearQueue->setIcon(QIcon::fromTheme("edit-clear-all"));
+    ui->btnQTop->setIcon(QIcon::fromTheme("go-top"));
+    ui->btnQUp->setIcon(QIcon::fromTheme("go-up"));
+    ui->btnQBottom->setIcon(QIcon::fromTheme("go-bottom"));
+    ui->btnQDown->setIcon(QIcon::fromTheme("go-down"));
+    ui->buttonPause->setIcon(QIcon::fromTheme("media-playback-pause"));
+    ui->buttonStop->setIcon(QIcon::fromTheme("media-playback-stop"));
+    ui->labelVolume->setPixmap(QIcon::fromTheme("player-volume").pixmap(QSize(16, 16)));
+    ui->pushButtonTempoDn->setIcon(QIcon::fromTheme("downindicator"));
+    ui->pushButtonTempoUp->setIcon(QIcon::fromTheme("upindicator"));
+    ui->pushButtonKeyDn->setIcon(QIcon::fromTheme("downindicator"));
+    ui->pushButtonKeyUp->setIcon(QIcon::fromTheme("upindicator"));
+    ui->btnSfxStop->setIcon(QIcon::fromTheme("media-playback-stop"));
+    ui->buttonBmPause->setIcon(QIcon::fromTheme("media-playback-pause"));
+    ui->buttonBmStop->setIcon(QIcon::fromTheme("media-playback-stop"));
+    ui->btnPlTop->setIcon(QIcon::fromTheme("go-top"));
+    ui->btnPlUp->setIcon(QIcon::fromTheme("go-up"));
+    ui->btnPlBottom->setIcon(QIcon::fromTheme("go-bottom"));
+    ui->btnPlDown->setIcon(QIcon::fromTheme("go-down"));
+    ui->labelVolumeBm->setPixmap(QIcon::fromTheme("player-volume").pixmap(QSize(16, 16)));
+    ui->buttonBmSearch->setIcon(QIcon::fromTheme("edit-find"));
 
     requestsDialog->updateIcons();
     treatAllSingersAsRegsChanged(m_settings.treatAllSingersAsRegs());

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1115,8 +1115,7 @@ QPushButton:default {
                             <string/>
                            </property>
                            <property name="icon">
-                            <iconset resource="resources.qrc">
-                             <normaloff>:/theme/Icons/okjbreeze-dark/actions/22/media-playlist-append.svg</normaloff>:/theme/Icons/okjbreeze-dark/actions/22/media-playlist-append.svg</iconset>
+                            <iconset theme="media-playlist-append"/>
                            </property>
                            <property name="iconSize">
                             <size>
@@ -1135,8 +1134,7 @@ QPushButton:default {
                             <string/>
                            </property>
                            <property name="icon">
-                            <iconset resource="resources.qrc">
-                             <normaloff>:/theme/Icons/okjbreeze-dark/actions/22/media-playback-start.svg</normaloff>:/theme/Icons/okjbreeze-dark/actions/22/media-playback-start.svg</iconset>
+                            <iconset theme="media-playback-start"/>
                            </property>
                            <property name="iconSize">
                             <size>
@@ -1594,9 +1592,7 @@ QPushButton:default {
                      <property name="text">
                       <string/>
                      </property>
-                     <property name="pixmap">
-                      <pixmap resource="resources.qrc">:/theme/Icons/okjbreeze/actions/16/player-volume.svg</pixmap>
-                     </property>
+                     <!-- pixmap set at runtime using QIcon::fromTheme -->
                      <property name="scaledContents">
                       <bool>true</bool>
                      </property>
@@ -2781,9 +2777,7 @@ QPushButton:default {
                           <property name="text">
                            <string/>
                           </property>
-                          <property name="pixmap">
-                           <pixmap resource="resources.qrc">:/theme/Icons/okjbreeze-dark/actions/16/player-volume.svg</pixmap>
-                          </property>
+                          <!-- pixmap set at runtime using QIcon::fromTheme -->
                          </widget>
                         </item>
                        </layout>

--- a/src/models/tablemodelhistorysingers.cpp
+++ b/src/models/tablemodelhistorysingers.cpp
@@ -4,7 +4,7 @@
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QPainter>
-#include <QSvgRenderer>
+#include <QIcon>
 
 
 TableModelHistorySingers::TableModelHistorySingers(QObject *parent)
@@ -190,18 +190,9 @@ okj::HistorySinger TableModelHistorySingers::getSinger(const int historySingerId
 
 void ItemDelegateHistorySingers::resizeIconsForFont(const QFont& font)
 {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
     m_curFontHeight = QFontMetrics(font).height();
-    m_iconDelete = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconLoadReg = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconDelete.fill(Qt::transparent);
-    m_iconLoadReg.fill(Qt::transparent);
-    QPainter painterDelete(&m_iconDelete);
-    QPainter painterLoad(&m_iconLoadReg);
-    QSvgRenderer svgrndrDelete(thm + "actions/16/edit-delete.svg");
-    QSvgRenderer svgrndrLoad(thm + "actions/16/list-add-user.svg");
-    svgrndrDelete.render(&painterDelete);
-    svgrndrLoad.render(&painterLoad);
+    m_iconDelete = QIcon::fromTheme("edit-delete").pixmap(m_curFontHeight, m_curFontHeight).toImage();
+    m_iconLoadReg = QIcon::fromTheme("list-add-user").pixmap(m_curFontHeight, m_curFontHeight).toImage();
 }
 
 ItemDelegateHistorySingers::ItemDelegateHistorySingers(QObject *parent) :

--- a/src/models/tablemodelkaraokesongs.cpp
+++ b/src/models/tablemodelkaraokesongs.cpp
@@ -3,11 +3,10 @@
 #include <QApplication>
 #include <QSqlQuery>
 #include <QSqlError>
-#include <QPainter>
 #include <QFileInfo>
 #include <QDir>
 #include <QDirIterator>
-#include <QSvgRenderer>
+#include <QIcon>
 #include <QMimeData>
 #include <array>
 
@@ -331,23 +330,10 @@ void TableModelKaraokeSongs::resizeIconsForFont(const QFont &font) {
     m_headerFont.setBold(true);
     m_itemFontMetrics = QFontMetrics(m_itemFont);
     m_itemHeight = m_itemFontMetrics.height() + 6;
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
     m_curFontHeight = QFontMetrics(font).height();
-    m_iconVid = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconZip = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconCdg = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconVid.fill(Qt::transparent);
-    m_iconZip.fill(Qt::transparent);
-    m_iconCdg.fill(Qt::transparent);
-    QPainter painterVid(&m_iconVid);
-    QPainter painterZip(&m_iconZip);
-    QPainter painterCdg(&m_iconCdg);
-    QSvgRenderer svgRndrVid(thm + "mimetypes/22/video-mp4.svg");
-    QSvgRenderer svgRndrZip(thm + "mimetypes/22/application-zip.svg");
-    QSvgRenderer svgRndrCdg(thm + "mimetypes/22/application-x-cda.svg");
-    svgRndrVid.render(&painterVid);
-    svgRndrZip.render(&painterZip);
-    svgRndrCdg.render(&painterCdg);
+    m_iconVid = QIcon::fromTheme("video-mp4").pixmap(m_curFontHeight, m_curFontHeight).toImage();
+    m_iconZip = QIcon::fromTheme("application-zip").pixmap(m_curFontHeight, m_curFontHeight).toImage();
+    m_iconCdg = QIcon::fromTheme("application-x-cda").pixmap(m_curFontHeight, m_curFontHeight).toImage();
 }
 
 

--- a/src/models/tablemodelplaylistsongs.cpp
+++ b/src/models/tablemodelplaylistsongs.cpp
@@ -9,7 +9,7 @@
 #include <QMimeData>
 #include <QJsonArray>
 #include <QJsonDocument>
-#include <QSvgRenderer>
+#include <QIcon>
 
 
 TableModelPlaylistSongs::TableModelPlaylistSongs(TableModelBreakSongs &breakSongsModel, QObject *parent)
@@ -269,18 +269,9 @@ int TableModelPlaylistSongs::getSongPositionById(const int plSongId) const {
 }
 
 void ItemDelegatePlaylistSongs::resizeIconsForFont(const QFont &font) {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
     m_curFontHeight = QFontMetrics(font).height();
-    m_iconDelete = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconPlaying = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconDelete.fill(Qt::transparent);
-    m_iconPlaying.fill(Qt::transparent);
-    QPainter painterDelete(&m_iconDelete);
-    QPainter painterPlaying(&m_iconPlaying);
-    QSvgRenderer svgrndrDelete(thm + "actions/16/edit-delete.svg");
-    QSvgRenderer svgrndrPlaying(thm + "actions/22/media-playback-start.svg");
-    svgrndrDelete.render(&painterDelete);
-    svgrndrPlaying.render(&painterPlaying);
+    m_iconDelete = QIcon::fromTheme("edit-delete").pixmap(m_curFontHeight, m_curFontHeight).toImage();
+    m_iconPlaying = QIcon::fromTheme("media-playback-start").pixmap(m_curFontHeight, m_curFontHeight).toImage();
 }
 
 ItemDelegatePlaylistSongs::ItemDelegatePlaylistSongs(QObject *parent) :

--- a/src/models/tablemodelqueuesongs.cpp
+++ b/src/models/tablemodelqueuesongs.cpp
@@ -7,7 +7,8 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QUrl>
-#include <QSvgRenderer>
+#include <QIcon>
+#include <QPainter>
 #include <spdlog/fmt/ostr.h>
 
 std::ostream & operator<<(std::ostream& os, const QString& s);
@@ -565,13 +566,8 @@ QSize TableModelQueueSongs::getColumnSizeHint(int section) const {
 }
 
 void ItemDelegateQueueSongs::resizeIconsForFont(const QFont &font) {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
     m_curFontHeight = QFontMetrics(font).height();
-    m_iconDelete = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconDelete.fill(Qt::transparent);
-    QPainter painterDelete(&m_iconDelete);
-    QSvgRenderer svgrndrDelete(thm + "actions/16/edit-delete.svg");
-    svgrndrDelete.render(&painterDelete);
+    m_iconDelete = QIcon::fromTheme("edit-delete").pixmap(m_curFontHeight, m_curFontHeight).toImage();
 }
 
 ItemDelegateQueueSongs::ItemDelegateQueueSongs(QObject *parent) :

--- a/src/models/tablemodelrequests.cpp
+++ b/src/models/tablemodelrequests.cpp
@@ -20,6 +20,7 @@
 
 #include "tablemodelrequests.h"
 #include <QDateTime>
+#include <QIcon>
 
 
 TableModelRequests::TableModelRequests(OKJSongbookAPI &songbookAPI, QObject *parent) :
@@ -27,9 +28,8 @@ TableModelRequests::TableModelRequests(OKJSongbookAPI &songbookAPI, QObject *par
         songbookApi(songbookAPI) {
     m_logger = spdlog::get("logger");
     connect(&songbookApi, &OKJSongbookAPI::requestsChanged, this, &TableModelRequests::requestsChanged);
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
-    delete16 = QIcon(thm + "actions/16/edit-delete.svg");
-    delete22 = QIcon(thm + "actions/22/edit-delete.svg");
+    delete16 = QIcon::fromTheme("edit-delete");
+    delete22 = QIcon::fromTheme("edit-delete");
 }
 
 void TableModelRequests::requestsChanged(const OkjsRequests &requests) {

--- a/src/models/tablemodelrotation.cpp
+++ b/src/models/tablemodelrotation.cpp
@@ -22,8 +22,9 @@
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QDateTime>
-#include <QSvgRenderer>
+#include <QIcon>
 #include <QMimeData>
+#include <QPainter>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <spdlog/spdlog.h>
@@ -599,28 +600,11 @@ void TableModelRotation::resizeIconsForFont(const QFont &font) {
 }
 
 void ItemDelegateRotation::resizeIconsForFont(const QFont &font) {
-    QString thm = (m_settings.theme() == 1) ? ":/theme/Icons/okjbreeze-dark/" : ":/theme/Icons/okjbreeze/";
     m_curFontHeight = QFontMetrics(font).height();
-    m_iconDelete = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconCurSinger = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconRegularOn = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconRegularOff = QImage(m_curFontHeight, m_curFontHeight, QImage::Format_ARGB32);
-    m_iconDelete.fill(Qt::transparent);
-    m_iconCurSinger.fill(Qt::transparent);
-    m_iconRegularOn.fill(Qt::transparent);
-    m_iconRegularOff.fill(Qt::transparent);
-    QPainter painterDelete(&m_iconDelete);
-    QPainter painterPlaying(&m_iconCurSinger);
-    QPainter painterRegularOn(&m_iconRegularOn);
-    QPainter painterRegularOff(&m_iconRegularOff);
-    QSvgRenderer svgRendererDelete(thm + "actions/16/edit-delete.svg");
-    QSvgRenderer svgRendererCurSinger(thm + "status/16/mic-on.svg");
-    QSvgRenderer svgRendererRegularOn(thm + "actions/16/im-user-online.svg");
-    QSvgRenderer svgRendererRegularOff(thm + "actions/16/im-user.svg");
-    svgRendererDelete.render(&painterDelete);
-    svgRendererCurSinger.render(&painterPlaying);
-    svgRendererRegularOn.render(&painterRegularOn);
-    svgRendererRegularOff.render(&painterRegularOff);
+    m_iconDelete = QIcon::fromTheme("edit-delete").pixmap(m_curFontHeight, m_curFontHeight).toImage();
+    m_iconCurSinger = QIcon::fromTheme("mic-on").pixmap(m_curFontHeight, m_curFontHeight).toImage();
+    m_iconRegularOn = QIcon::fromTheme("im-user-online").pixmap(m_curFontHeight, m_curFontHeight).toImage();
+    m_iconRegularOff = QIcon::fromTheme("im-user").pixmap(m_curFontHeight, m_curFontHeight).toImage();
 }
 
 [[maybe_unused]] ItemDelegateRotation::ItemDelegateRotation(QObject *parent) :


### PR DESCRIPTION
## Summary
- register bundled icon directories via `QIcon::setFallbackSearchPaths`
- switch UI components to `QIcon::fromTheme` and scalable SVG icons
- update models and dialogs to render icons from theme resources

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*


------
https://chatgpt.com/codex/tasks/task_e_68952f2b00e08330b75bcd5b6f9414bb