### PR TITLE
Avoid large reserves in duration updater

### DIFF
--- a/src/durationlazyupdater.cpp
+++ b/src/durationlazyupdater.cpp
@@ -64,7 +64,8 @@ void LazyDurationUpdateController::getSongsRequiringUpdate()
     files.clear();
     QSqlQuery query;
     query.exec("SELECT path FROM dbsongs WHERE duration < 1 ORDER BY artist, title");
-    files.reserve(query.size());
+    // Append results without pre-reserving to avoid large memory allocations when
+    // processing extensive result sets.
     while (query.next())
     {
         files.append(query.value(0).toString());


### PR DESCRIPTION
## Summary
- prevent `files.reserve(query.size())` from loading all results at once in duration updater

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(build interrupted after 75%)*

------
https://chatgpt.com/codex/tasks/task_e_68952f54b64c83309b68d708544393f7