### PR TITLE
Refine BMDB update thread error handling

### DIFF
--- a/src/bmdbupdatethread.cpp
+++ b/src/bmdbupdatethread.cpp
@@ -16,154 +16,126 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
 
 #include "bmdbupdatethread.h"
+#include "tagreader.h"
+#include <QApplication>
 #include <QDir>
 #include <QDirIterator>
-#include <QSqlQuery>
 #include <QFileInfo>
-#include <QApplication>
-#include "tagreader.h"
+#include <QSqlError>
+#include <QSqlQuery>
 #include <QtConcurrent>
+#include <csignal>
 
-BmDbUpdateThread::BmDbUpdateThread(QObject *parent) :
-    QThread(parent)
-{
-    supportedExtensions.append(".mp3");
-    supportedExtensions.append(".wav");
-    supportedExtensions.append(".ogg");
-    supportedExtensions.append(".flac");
-    supportedExtensions.append(".m4a");
-    supportedExtensions.append(".mkv");
-    supportedExtensions.append(".avi");
-    supportedExtensions.append(".mp4");
-    supportedExtensions.append(".mpg");
-    supportedExtensions.append(".mpeg");
-    supportedExtensions.append(".wmv");
-    supportedExtensions.append(".wma");
+BmDbUpdateThread::BmDbUpdateThread(QObject *parent) : QThread(parent) {
+  supportedExtensions.append(".mp3");
+  supportedExtensions.append(".wav");
+  supportedExtensions.append(".ogg");
+  supportedExtensions.append(".flac");
+  supportedExtensions.append(".m4a");
+  supportedExtensions.append(".mkv");
+  supportedExtensions.append(".avi");
+  supportedExtensions.append(".mp4");
+  supportedExtensions.append(".mpg");
+  supportedExtensions.append(".mpeg");
+  supportedExtensions.append(".wmv");
+  supportedExtensions.append(".wma");
 }
 
-QString BmDbUpdateThread::path() const
-{
-    return m_path;
-}
+QString BmDbUpdateThread::path() const { return m_path; }
 
-void BmDbUpdateThread::setPath(const QString &path)
-{
-    m_path = path;
-}
+void BmDbUpdateThread::setPath(const QString &path) { m_path = path; }
 
-QStringList BmDbUpdateThread::findMediaFiles(const QString& directory)
-{
-    QStringList files;
-    QDir dir(directory);
-    QDirIterator iterator(dir.absolutePath(), QDirIterator::Subdirectories);
-    while (iterator.hasNext()) {
-        iterator.next();
-        if (!iterator.fileInfo().isDir()) {
-            QString filename = iterator.filePath();
-            for (int i=0; i<supportedExtensions.size(); i++)
-            {
-                if (filename.endsWith(supportedExtensions.at(i),Qt::CaseInsensitive))
-                {
-                    files.append(filename);
-                    break;
-                }
-            }
+QStringList BmDbUpdateThread::findMediaFiles(const QString &directory) {
+  QStringList files;
+  QDir dir(directory);
+  QDirIterator iterator(dir.absolutePath(), QDirIterator::Subdirectories);
+  while (iterator.hasNext()) {
+    iterator.next();
+    if (!iterator.fileInfo().isDir()) {
+      QString filename = iterator.filePath();
+      for (int i = 0; i < supportedExtensions.size(); i++) {
+        if (filename.endsWith(supportedExtensions.at(i), Qt::CaseInsensitive)) {
+          files.append(filename);
+          break;
         }
+      }
     }
-    return files;
+  }
+  return files;
 }
 
-void BmDbUpdateThread::run()
-{
-    database.open();
-    qInfo() << database.lastError();
-    TagReader reader;
-    emit progressChanged(0, 0);
-    emit progressMessage("Getting list of files in " + m_path);
-    emit stateChanged("Finding media files...");
-    QStringList files = findMediaFiles(m_path);
-    emit progressMessage("Found " + QString::number(files.size()) + " files.");
-    QSqlQuery query(database);
-    emit stateChanged("Getting metadata and adding songs to the database");
-    emit progressMessage("Getting metadata and adding songs to the database");
-    qInfo() << "Setting sqlite synchronous mode to OFF";
-    query.exec("PRAGMA synchronous=OFF");
-    qInfo() << query.lastError();
-    qInfo() << "Increasing sqlite cache size";
-    query.exec("PRAGMA cache_size=500000");
-    qInfo() << query.lastError();
-    query.exec("PRAGMA temp_store=2");
-    qInfo() << "Beginning transaction";
-    query.exec("BEGIN TRANSACTION");
-    qInfo() << query.lastError();
-    query.prepare("INSERT OR IGNORE INTO bmsongs (artist,title,path,filename,duration,searchstring) VALUES(:artist, :title, :path, :filename, :duration, :searchstring)");
-    for (int i=0; i < files.size(); i++)
-    {
-        QFileInfo fi(files.at(i));
-        emit progressMessage("Processing file: " + fi.fileName());
-        reader.setMedia(files.at(i));
-        QString duration = QString::number(reader.getDuration() / 1000);
-        QString artist = reader.getArtist();
-        QString title = reader.getTitle();
-        query.bindValue(":artist", artist);
-        query.bindValue(":title", title);
-        query.bindValue(":path", files.at(i));
-        query.bindValue(":filename", files.at(i));
-        query.bindValue(":duration", duration);
-        query.bindValue(":searchstring", artist + title + files.at(i));
-        query.exec();
-        emit progressChanged(i + 1, files.size());
-    }
-    query.exec("COMMIT TRANSACTION");
-    qInfo() << query.lastError();
-    emit progressMessage("Finished processing files for directory: " + m_path);
-    database.close();
+void BmDbUpdateThread::run() {
+  if (!database.open()) {
+    qCritical() << database.lastError();
+    std::raise(SIGABRT);
+  }
+
+  process(false);
+  database.close();
 }
 
-void BmDbUpdateThread::startUnthreaded()
-{
-    TagReader reader;
-    emit progressChanged(0, 0);
-    emit progressMessage("Getting list of files in " + m_path);
-    emit stateChanged("Finding media files...");
-    QStringList files = findMediaFiles(m_path);
-    emit progressMessage("Found " + QString::number(files.size()) + " files.");
-    QSqlQuery query;
-    emit stateChanged("Getting metadata and adding songs to the database");
-    emit progressMessage("Getting metadata and adding songs to the database");
-    qInfo() << "Setting sqlite synchronous mode to OFF";
-    query.exec("PRAGMA synchronous=OFF");
-    qInfo() << query.lastError();
-    qInfo() << "Increasing sqlite cache size";
-    query.exec("PRAGMA cache_size=500000");
-    qInfo() << query.lastError();
-    query.exec("PRAGMA temp_store=2");
-    qInfo() << "Beginning transaction";
-    database.transaction();
-    qInfo() << query.lastError();
-    query.prepare("INSERT OR IGNORE INTO bmsongs (artist,title,path,filename,duration,searchstring) VALUES(:artist, :title, :path, :filename, :duration, :searchstring)");
-    for (int i=0; i < files.size(); i++)
-    {
-        QApplication::processEvents();
-        QFileInfo fi(files.at(i));
-        emit progressMessage("Processing file: " + fi.fileName());
-        reader.setMedia(files.at(i));
-        QString duration = QString::number(reader.getDuration() / 1000);
-        QString artist = reader.getArtist();
-        QString title = reader.getTitle();
-        query.bindValue(":artist", artist);
-        query.bindValue(":title", title);
-        query.bindValue(":path", files.at(i));
-        query.bindValue(":filename", files.at(i));
-        query.bindValue(":duration", duration);
-        query.bindValue(":searchstring", artist + title + files.at(i));
-        query.exec();
-        emit progressChanged(i + 1, files.size());
+void BmDbUpdateThread::startUnthreaded() {
+  if (!database.isOpen() && !database.open()) {
+    qCritical() << database.lastError();
+    std::raise(SIGABRT);
+  }
+
+  process(true);
+}
+
+void BmDbUpdateThread::process(bool processEvents) {
+  TagReader reader;
+  emit progressChanged(0, 0);
+  emit progressMessage("Getting list of files in " + m_path);
+  emit stateChanged("Finding media files...");
+  QStringList files = findMediaFiles(m_path);
+  emit progressMessage("Found " + QString::number(files.size()) + " files.");
+  QSqlQuery query(database);
+  emit stateChanged("Getting metadata and adding songs to the database");
+  emit progressMessage("Getting metadata and adding songs to the database");
+  qInfo() << "Setting sqlite synchronous mode to OFF";
+  if (!query.exec("PRAGMA synchronous=OFF"))
+    qWarning() << query.lastError();
+  qInfo() << "Increasing sqlite cache size";
+  if (!query.exec("PRAGMA cache_size=500000"))
+    qWarning() << query.lastError();
+  if (!query.exec("PRAGMA temp_store=2"))
+    qWarning() << query.lastError();
+  qInfo() << "Beginning transaction";
+  if (!database.transaction()) {
+    qCritical() << database.lastError();
+    return;
+  }
+  if (!query.prepare(
+          "INSERT OR IGNORE INTO bmsongs "
+          "(artist,title,path,filename,duration,searchstring) VALUES(:artist, "
+          ":title, :path, :filename, :duration, :searchstring)"))
+    qWarning() << query.lastError();
+  for (int i = 0; i < files.size(); ++i) {
+    if (processEvents)
+      QApplication::processEvents();
+    QFileInfo fi(files.at(i));
+    emit progressMessage("Processing file: " + fi.fileName());
+    reader.setMedia(files.at(i));
+    QString duration = QString::number(reader.getDuration() / 1000);
+    QString artist = reader.getArtist();
+    QString title = reader.getTitle();
+    query.bindValue(":artist", artist);
+    query.bindValue(":title", title);
+    query.bindValue(":path", files.at(i));
+    query.bindValue(":filename", files.at(i));
+    query.bindValue(":duration", duration);
+    query.bindValue(":searchstring", artist + title + files.at(i));
+    if (!query.exec()) {
+      qWarning() << query.lastError();
+      continue;
     }
-    database.commit();
-    qInfo() << query.lastError();
-    emit progressMessage("Finished processing files for directory: " + m_path);
+    emit progressChanged(i + 1, files.size());
+  }
+  if (!database.commit())
+    qWarning() << database.lastError();
+  emit progressMessage("Finished processing files for directory: " + m_path);
 }

--- a/src/bmdbupdatethread.h
+++ b/src/bmdbupdatethread.h
@@ -16,39 +16,37 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
 
 #ifndef BMDBUPDATETHREAD_H
 #define BMDBUPDATETHREAD_H
 
-#include <QThread>
 #include <QStringList>
+#include <QThread>
 #include <QtSql>
 
-class BmDbUpdateThread : public QThread
-{
-    Q_OBJECT
+class BmDbUpdateThread : public QThread {
+  Q_OBJECT
 public:
-    explicit BmDbUpdateThread(QObject *parent = nullptr);
-    void run() override;
-    void startUnthreaded();
-    [[nodiscard]] QString path() const;
-    void setPath(const QString &path);
+  explicit BmDbUpdateThread(QObject *parent = nullptr);
+  void run() override;
+  void startUnthreaded();
+  [[nodiscard]] QString path() const;
+  void setPath(const QString &path);
 
 signals:
-    void progressMessage(QString msg);
-    void stateChanged(QString state);
-    void progressChanged(int progress, int max);
-    
+  void progressMessage(QString msg);
+  void stateChanged(QString state);
+  void progressChanged(int progress, int max);
+
 public slots:
 
 private:
-    QString m_path;
-    QStringList findMediaFiles(const QString& directory);
-    QStringList supportedExtensions;
-    QSqlDatabase database;
-
-    
+  QString m_path;
+  QStringList findMediaFiles(const QString &directory);
+  QStringList supportedExtensions;
+  QSqlDatabase database;
+  void process(bool processEvents);
 };
 
 #endif // BMDBUPDATETHREAD_H


### PR DESCRIPTION
## Summary
- Ensure database connection succeeds before processing and abort with signal on failure
- Consolidate repeated logic from threaded and unthreaded paths into shared function with robust query error handling

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*


------
https://chatgpt.com/codex/tasks/task_e_68952ff76c948330a4bd309fefc77439