### PR TITLE
Make media tasks asynchronous

### DIFF
--- a/THREADING.md
+++ b/THREADING.md
@@ -1,0 +1,7 @@
+# Threading Guidelines
+
+- The GUI thread must remain responsive. Avoid blocking database or file I/O on the UI thread.
+- Use `QThread` workers or `QtConcurrent`/`QFutureWatcher` for long-running operations such as song import, media scanning, JSON parsing and network I/O.
+- Communicate between threads using queued signals and slots. Do not access `QWidget` objects outside the GUI thread.
+- Provide a cancellation mechanism for worker threads. Workers should periodically check a cancel token and exit gracefully when requested.
+- Ensure that any temporary files or network requests are cleaned up when a task is canceled.

--- a/src/bmdbdialog.cpp
+++ b/src/bmdbdialog.cpp
@@ -77,32 +77,22 @@ void BmDbDialog::pushButtonUpdateClicked() {
     m_dbUpdateDlg.show();
     auto thread = new BmDbUpdateThread(this);
     thread->setPath(path);
-    connect(thread, &BmDbUpdateThread::progressMessage, &m_dbUpdateDlg, &DlgDbUpdate::addLogMsg);
-    connect(thread, &BmDbUpdateThread::stateChanged, &m_dbUpdateDlg, &DlgDbUpdate::changeStatusTxt);
-    connect(thread, &BmDbUpdateThread::progressChanged, &m_dbUpdateDlg, &DlgDbUpdate::changeProgress);
-    thread->startUnthreaded();
-    QMessageBox::information(this, tr("Update Complete"), tr("Database update complete."));
-    m_dbUpdateDlg.hide();
-    emit bmDbUpdated();
-    delete (thread);
+    connect(thread, &BmDbUpdateThread::progressMessage, &m_dbUpdateDlg, &DlgDbUpdate::addLogMsg, Qt::QueuedConnection);
+    connect(thread, &BmDbUpdateThread::stateChanged, &m_dbUpdateDlg, &DlgDbUpdate::changeStatusTxt, Qt::QueuedConnection);
+    connect(thread, &BmDbUpdateThread::progressChanged, &m_dbUpdateDlg, &DlgDbUpdate::changeProgress, Qt::QueuedConnection);
+    connect(thread, &QThread::finished, this, [this, thread]() {
+        QMessageBox::information(this, tr("Update Complete"), tr("Database update complete."));
+        m_dbUpdateDlg.hide();
+        emit bmDbUpdated();
+        thread->deleteLater();
+    }, Qt::QueuedConnection);
+    thread->start();
 }
 
 void BmDbDialog::pushButtonUpdateAllClicked() {
     m_dbUpdateDlg.reset();
     m_dbUpdateDlg.show();
-    for (int i = 0; i < m_pathsModel.rowCount(); i++) {
-        QApplication::processEvents();
-        auto thread = new BmDbUpdateThread(this);
-        thread->setPath(m_pathsModel.data(m_pathsModel.index(i, 0)).toString());
-        connect(thread, &BmDbUpdateThread::progressMessage, &m_dbUpdateDlg, &DlgDbUpdate::addLogMsg);
-        connect(thread, &BmDbUpdateThread::stateChanged, &m_dbUpdateDlg, &DlgDbUpdate::changeStatusTxt);
-        connect(thread, &BmDbUpdateThread::progressChanged, &m_dbUpdateDlg, &DlgDbUpdate::changeProgress);
-        thread->startUnthreaded();
-        delete (thread);
-    }
-    QMessageBox::information(this, tr("Update Complete"), tr("Database update complete."));
-    m_dbUpdateDlg.hide();
-    emit bmDbUpdated();
+    updateNextPath(0);
 }
 
 void BmDbDialog::pushButtonClearDbClicked() {
@@ -128,6 +118,26 @@ void BmDbDialog::pushButtonDeleteClicked() {
     m_pathsModel.removeRow(ui->tableViewPaths->selectionModel()->selectedIndexes().at(0).row());
     m_pathsModel.select();
     m_pathsModel.submitAll();
+}
+
+void BmDbDialog::updateNextPath(int index) {
+    if (index >= m_pathsModel.rowCount()) {
+        QMessageBox::information(this, tr("Update Complete"), tr("Database update complete."));
+        m_dbUpdateDlg.hide();
+        emit bmDbUpdated();
+        return;
+    }
+    auto path = m_pathsModel.data(m_pathsModel.index(index, 0)).toString();
+    auto thread = new BmDbUpdateThread(this);
+    thread->setPath(path);
+    connect(thread, &BmDbUpdateThread::progressMessage, &m_dbUpdateDlg, &DlgDbUpdate::addLogMsg, Qt::QueuedConnection);
+    connect(thread, &BmDbUpdateThread::stateChanged, &m_dbUpdateDlg, &DlgDbUpdate::changeStatusTxt, Qt::QueuedConnection);
+    connect(thread, &BmDbUpdateThread::progressChanged, &m_dbUpdateDlg, &DlgDbUpdate::changeProgress, Qt::QueuedConnection);
+    connect(thread, &QThread::finished, this, [this, thread, index]() {
+        thread->deleteLater();
+        updateNextPath(index + 1);
+    }, Qt::QueuedConnection);
+    thread->start();
 }
 
 

--- a/src/bmdbdialog.h
+++ b/src/bmdbdialog.h
@@ -56,6 +56,7 @@ private:
     std::unique_ptr<Ui::BmDbDialog> ui;
     QSqlTableModel m_pathsModel;
     DlgDbUpdate m_dbUpdateDlg{this};
+    void updateNextPath(int index);
 };
 
 #endif // BMDBDIALOG_H

--- a/src/bmdbupdatethread.cpp
+++ b/src/bmdbupdatethread.cpp
@@ -102,6 +102,8 @@ void BmDbUpdateThread::run()
     query.prepare("INSERT OR IGNORE INTO bmsongs (artist,title,path,filename,duration,searchstring) VALUES(:artist, :title, :path, :filename, :duration, :searchstring)");
     for (int i=0; i < files.size(); i++)
     {
+        if (m_cancelRequested.load())
+            break;
         QFileInfo fi(files.at(i));
         emit progressMessage("Processing file: " + fi.fileName());
         reader.setMedia(files.at(i));
@@ -117,9 +119,14 @@ void BmDbUpdateThread::run()
         query.exec();
         emit progressChanged(i + 1, files.size());
     }
-    query.exec("COMMIT TRANSACTION");
+    if (m_cancelRequested.load()) {
+        query.exec("ROLLBACK TRANSACTION");
+        emit progressMessage("Update canceled for directory: " + m_path);
+    } else {
+        query.exec("COMMIT TRANSACTION");
+        emit progressMessage("Finished processing files for directory: " + m_path);
+    }
     qInfo() << query.lastError();
-    emit progressMessage("Finished processing files for directory: " + m_path);
     database.close();
 }
 
@@ -147,6 +154,8 @@ void BmDbUpdateThread::startUnthreaded()
     query.prepare("INSERT OR IGNORE INTO bmsongs (artist,title,path,filename,duration,searchstring) VALUES(:artist, :title, :path, :filename, :duration, :searchstring)");
     for (int i=0; i < files.size(); i++)
     {
+        if (m_cancelRequested.load())
+            break;
         QApplication::processEvents();
         QFileInfo fi(files.at(i));
         emit progressMessage("Processing file: " + fi.fileName());
@@ -163,7 +172,17 @@ void BmDbUpdateThread::startUnthreaded()
         query.exec();
         emit progressChanged(i + 1, files.size());
     }
-    database.commit();
+    if (m_cancelRequested.load()) {
+        database.rollback();
+        emit progressMessage("Update canceled for directory: " + m_path);
+    } else {
+        database.commit();
+        emit progressMessage("Finished processing files for directory: " + m_path);
+    }
     qInfo() << query.lastError();
-    emit progressMessage("Finished processing files for directory: " + m_path);
+}
+
+void BmDbUpdateThread::cancel()
+{
+    m_cancelRequested.store(true);
 }

--- a/src/bmdbupdatethread.h
+++ b/src/bmdbupdatethread.h
@@ -24,6 +24,7 @@
 #include <QThread>
 #include <QStringList>
 #include <QtSql>
+#include <atomic>
 
 class BmDbUpdateThread : public QThread
 {
@@ -41,14 +42,15 @@ signals:
     void progressChanged(int progress, int max);
     
 public slots:
+    void cancel();
 
 private:
     QString m_path;
     QStringList findMediaFiles(const QString& directory);
     QStringList supportedExtensions;
     QSqlDatabase database;
+    std::atomic_bool m_cancelRequested{false};
 
-    
 };
 
 #endif // BMDBUPDATETHREAD_H

--- a/src/songshop.cpp
+++ b/src/songshop.cpp
@@ -4,9 +4,9 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QCryptographicHash>
-#include <QEventLoop>
 #include <QFileInfo>
 #include <QDir>
+#include <QFile>
 
 
 SongShop::SongShop(QObject *parent) : QObject(parent) {
@@ -86,21 +86,22 @@ void SongShop::downloadFile(const QString &url, const QString &destFn) {
     if (!QDir(destDir).exists())
         QDir().mkdir(destDir);
     QString destPath = destDir + destFn;
-    QNetworkAccessManager m_NetworkMngr;
-    QNetworkReply *reply = m_NetworkMngr.get(QNetworkRequest(url));
-    QEventLoop loop;
-    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
-    connect(reply, &QNetworkReply::downloadProgress, this, &SongShop::onDownloadProgress);
-    loop.exec();
-    QUrl aUrl(url);
-    QFileInfo fileInfo = aUrl.path();
-    QFile file(destPath);
-    file.open(QIODevice::WriteOnly);
-    file.write(reply->readAll());
-    delete reply;
-    emit karaokeSongDownloaded(destPath);
-    // clear session ID to force login again before next download.  Workaround for expiring PartyTyme logins.
-    knSessionId = "";
+    if (m_downloadReply)
+        return;
+    m_cancelDownload = false;
+    m_downloadFile.setFileName(destPath);
+    if (!m_downloadFile.open(QIODevice::WriteOnly))
+        return;
+    QNetworkRequest request(QUrl(url));
+    m_downloadReply = manager->get(request);
+    connect(m_downloadReply, &QNetworkReply::finished, this, &SongShop::onDownloadFinished, Qt::QueuedConnection);
+    connect(m_downloadReply, &QNetworkReply::downloadProgress, this, &SongShop::onDownloadProgress, Qt::QueuedConnection);
+}
+
+void SongShop::cancelDownload() {
+    m_cancelDownload = true;
+    if (m_downloadReply)
+        m_downloadReply->abort();
 }
 
 void SongShop::onSslErrors(QNetworkReply *reply, QList<QSslError> errors) {
@@ -172,6 +173,21 @@ void SongShop::onNetworkReply(QNetworkReply *reply) {
         emit paymentProcessingFailed();
     } else
         m_logger->warn("{} Unexpected JSON data received: {}", m_loggingPrefix, data.toStdString());
+}
+
+void SongShop::onDownloadFinished() {
+    if (!m_downloadReply)
+        return;
+    if (m_cancelDownload || m_downloadReply->error() == QNetworkReply::OperationCanceledError) {
+        m_downloadFile.remove();
+    } else {
+        m_downloadFile.write(m_downloadReply->readAll());
+        emit karaokeSongDownloaded(m_downloadFile.fileName());
+        knSessionId = "";
+    }
+    m_downloadFile.close();
+    m_downloadReply->deleteLater();
+    m_downloadReply = nullptr;
 }
 
 void SongShop::onDownloadProgress(qint64 received, qint64 total) {

--- a/src/songshop.h
+++ b/src/songshop.h
@@ -5,6 +5,7 @@
 #include <QNetworkReply>
 #include <QObject>
 #include <QUrl>
+#include <QFile>
 #include "settings.h"
 #include <spdlog/spdlog.h>
 #include <spdlog/async_logger.h>
@@ -53,6 +54,9 @@ private:
     QString knSessionId;
     bool knLoginError;
     void downloadFile(const QString &url, const QString &destFn);
+    QNetworkReply *m_downloadReply{nullptr};
+    QFile m_downloadFile;
+    bool m_cancelDownload{false};
     QString dlArtist;
     QString dlTitle;
     QString dlSongId;
@@ -69,10 +73,13 @@ signals:
 
 public slots:
 
+    void cancelDownload();
+
 private slots:
     void onSslErrors(QNetworkReply * reply, QList<QSslError> errors);
     void onNetworkReply(QNetworkReply* reply);
     void onDownloadProgress(qint64 received, qint64 total);
+    void onDownloadFinished();
 };
 
 #endif // SONGSHOP_H


### PR DESCRIPTION
## Summary
- Add threading guidelines emphasizing queued signals and cancel tokens
- Convert SongShop downloads to non-blocking QNetworkReply with cancellation
- Add cancellable BmDbUpdateThread and run updates in background threads

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1c1b976c833084e8fa9c12f4cde9