### PR TITLE
Add MediaService wrapper for GStreamer pipelines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,7 @@ set(SOURCE_FILES
         src/main.cpp
         src/dlgaddsong.cpp
         src/mediabackend.cpp
+        src/mediaservice.cpp
         src/mzarchive.cpp
         src/okjutil.h
         src/okjtypes.cpp
@@ -475,6 +476,7 @@ set(SOURCE_FILES
         src/dlgaddsong.h
         src/dlgvideopreview.h
         src/mediabackend.h
+        src/mediaservice.h
         src/mzarchive.h
         src/okjutil.h
         src/okjtypes.h

--- a/src/mediaservice.cpp
+++ b/src/mediaservice.cpp
@@ -1,0 +1,136 @@
+#include "mediaservice.h"
+
+#include <QTimer>
+
+MediaService::MediaService(QObject *parent)
+    : QObject(parent)
+{
+    if (!gst_is_initialized()) {
+        gst_init(nullptr, nullptr);
+    }
+
+    m_pipeline = gst_element_factory_make("playbin", "media_service_pipeline");
+    m_bus = gst_element_get_bus(m_pipeline);
+
+    auto *timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, [this]() {
+        while (gst_bus_have_pending(m_bus)) {
+            auto msg = gst_bus_pop(m_bus);
+            handleBusMessage(msg);
+            gst_message_unref(msg);
+        }
+    });
+    timer->start(50);
+}
+
+MediaService::~MediaService()
+{
+    if (m_pipeline) {
+        gst_element_set_state(m_pipeline, GST_STATE_NULL);
+        gst_object_unref(m_pipeline);
+    }
+    if (m_bus) {
+        gst_object_unref(m_bus);
+    }
+}
+
+void MediaService::load(const QString &uri)
+{
+    if (!m_pipeline)
+        return;
+
+    setState(State::Loading);
+    auto gstUri = gst_filename_to_uri(uri.toLocal8Bit(), nullptr);
+    g_object_set(m_pipeline, "uri", gstUri, nullptr);
+    g_free(gstUri);
+    gst_element_set_state(m_pipeline, GST_STATE_READY);
+}
+
+void MediaService::play()
+{
+    if (!m_pipeline)
+        return;
+
+    gst_element_set_state(m_pipeline, GST_STATE_PLAYING);
+}
+
+void MediaService::pause()
+{
+    if (!m_pipeline)
+        return;
+
+    gst_element_set_state(m_pipeline, GST_STATE_PAUSED);
+}
+
+void MediaService::stop()
+{
+    if (!m_pipeline)
+        return;
+
+    gst_element_set_state(m_pipeline, GST_STATE_NULL);
+    m_retryCount = 0;
+    setState(State::Stopped);
+}
+
+void MediaService::setState(State state)
+{
+    if (m_state == state)
+        return;
+    m_state = state;
+    emit stateChanged(m_state);
+}
+
+void MediaService::handleBusMessage(GstMessage *msg)
+{
+    switch (GST_MESSAGE_TYPE(msg)) {
+    case GST_MESSAGE_ERROR: {
+        GError *err;
+        gchar *debug;
+        gst_message_parse_error(msg, &err, &debug);
+        QString message = QString::fromUtf8(err->message);
+        g_error_free(err);
+        g_free(debug);
+        m_retryCount++;
+        if (m_retryCount <= m_maxRetries) {
+            attemptRestart();
+        } else {
+            setState(State::Error);
+            emit errorOccurred(message);
+        }
+        break;
+    }
+    case GST_MESSAGE_EOS:
+        stop();
+        break;
+    case GST_MESSAGE_STATE_CHANGED:
+        if (GST_MESSAGE_SRC(msg) == GST_OBJECT(m_pipeline)) {
+            GstState newState;
+            gst_message_parse_state_changed(msg, nullptr, &newState, nullptr);
+            switch (newState) {
+            case GST_STATE_PLAYING:
+                setState(State::Playing);
+                break;
+            case GST_STATE_PAUSED:
+                setState(State::Paused);
+                break;
+            case GST_STATE_READY:
+                if (m_state == State::Loading)
+                    setState(State::Paused);
+                break;
+            default:
+                break;
+            }
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+void MediaService::attemptRestart()
+{
+    gst_element_set_state(m_pipeline, GST_STATE_NULL);
+    gst_element_set_state(m_pipeline, GST_STATE_READY);
+    gst_element_set_state(m_pipeline, GST_STATE_PLAYING);
+    setState(State::Loading);
+}

--- a/src/mediaservice.h
+++ b/src/mediaservice.h
@@ -1,0 +1,45 @@
+#ifndef MEDIASERVICE_H
+#define MEDIASERVICE_H
+
+#include <QObject>
+#include <QString>
+#include <gst/gst.h>
+
+class MediaService : public QObject
+{
+    Q_OBJECT
+public:
+    enum class State {
+        Idle,
+        Loading,
+        Playing,
+        Paused,
+        Stopped,
+        Error
+    };
+
+    explicit MediaService(QObject *parent = nullptr);
+    ~MediaService() override;
+
+    void load(const QString &uri);
+    void play();
+    void pause();
+    void stop();
+
+signals:
+    void stateChanged(MediaService::State state);
+    void errorOccurred(const QString &message);
+
+private:
+    void setState(State state);
+    void handleBusMessage(GstMessage *msg);
+    void attemptRestart();
+
+    GstElement *m_pipeline { nullptr };
+    GstBus *m_bus { nullptr };
+    State m_state { State::Idle };
+    int m_retryCount { 0 };
+    const int m_maxRetries { 3 };
+};
+
+#endif // MEDIASERVICE_H


### PR DESCRIPTION
## Summary
- add MediaService class wrapping GStreamer playbin with explicit Idle/Loading/Playing/Paused/Stopped/Error states
- implement error handling with automatic retries and user-visible error notifications
- hook new service into build configuration

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt5Config.cmake, qt5-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1c2b20e0833081f609f07eb3aa53