### PR TITLE
Add structured error handling and categorized logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,7 @@ set(SOURCE_FILES
         src/dlgaddsinger.cpp
         src/songshop.cpp
         src/dlgsongshop.cpp
+        src/logging.cpp
         src/simplecrypt.cpp
         src/dlgsongshoppurchase.cpp
         src/dlgsetpassword.cpp

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QString>
+#include <QSqlError>
+#include <QNetworkReply>
+
+namespace okj {
+
+enum class ErrorCode {
+    None,
+    Database,
+    Network,
+    Unknown
+};
+
+struct Error {
+    ErrorCode code{ErrorCode::None};
+    QString message;
+
+    static Error fromSqlError(const QSqlError &err) {
+        return {ErrorCode::Database, err.text()};
+    }
+
+    static Error fromNetworkError(QNetworkReply::NetworkError err, const QString &msg) {
+        return {ErrorCode::Network, msg.isEmpty() ? QString::number(static_cast<int>(err)) : msg};
+    }
+};
+
+} // namespace okj
+

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,0 +1,6 @@
+#include "logging.h"
+
+Q_LOGGING_CATEGORY(appLog, "openkj.app")
+Q_LOGGING_CATEGORY(dbLog, "openkj.db")
+Q_LOGGING_CATEGORY(netLog, "openkj.net")
+

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(appLog)
+Q_DECLARE_LOGGING_CATEGORY(dbLog)
+Q_DECLARE_LOGGING_CATEGORY(netLog)
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,8 @@
 #include "idledetect.h"
 #include "runguard/runguard.h"
 #include "okjversion.h"
-#include <spdlog/sinks/basic_file_sink.h>
+#include "logging.h"
+#include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/async_logger.h>
 #include <spdlog/async.h>
@@ -48,6 +49,11 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
     if (context.function) {
         logMsg.append(" [");
         logMsg.append(context.function);
+        logMsg.append("]");
+    }
+    if (context.category) {
+        logMsg.append(" [");
+        logMsg.append(context.category);
         logMsg.append("]");
     }
     switch (type) {
@@ -80,7 +86,7 @@ int main(int argc, char *argv[]) {
     logFilePath = logDir + QDir::separator() + filename;
 
     auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFilePath.toStdString(), false);
+    auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logFilePath.toStdString(), 1024 * 1024 * 5, 3);
     spdlog::init_thread_pool(8192, 2);
     std::vector<spdlog::sink_ptr> sinks{console_sink, file_sink};
     logger = std::make_shared<spdlog::async_logger>("logger", sinks.begin(), sinks.end(), spdlog::thread_pool(),
@@ -146,11 +152,9 @@ int main(int argc, char *argv[]) {
     console_sink->set_pattern("[%^%l%$] %v");
     file_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
 
-    logger->info("OpenKJ version {} starting up", OKJ_VERSION_STRING);
-
-
-    //QLoggingCategory::setFilterRules("*.debug=true");
     qInstallMessageHandler(myMessageOutput);
+    qCInfo(appLog) << "OpenKJ version" << OKJ_VERSION_STRING << "starting up";
+    //QLoggingCategory::setFilterRules("*.debug=true");
     QApplication a(argc, argv);
 
 #ifdef MAC_OVERRIDE_GST

--- a/src/models/tablemodelhistorysongs.cpp
+++ b/src/models/tablemodelhistorysongs.cpp
@@ -6,6 +6,8 @@
 #include <QSqlError>
 #include <QFontMetrics>
 #include <QSqlQuery>
+#include "logging.h"
+#include "error.h"
 
 TableModelHistorySongs::TableModelHistorySongs(TableModelKaraokeSongs &songsModel) : m_karaokeSongsModel(songsModel) {
     m_logger = spdlog::get("logger");
@@ -153,8 +155,10 @@ void TableModelHistorySongs::saveSong(const QString &singerName, const QString &
         query.bindValue(":historysinger", historySingerId);
         query.bindValue(":datetime", QDateTime::currentDateTime());
         query.exec();
-        if (auto error = query.lastError(); error.type() != QSqlError::NoError)
-            m_logger->error("{} DB error: {}", m_loggingPrefix, error.text());
+        if (auto error = query.lastError(); error.type() != QSqlError::NoError) {
+            auto err = okj::Error::fromSqlError(error);
+            qCWarning(dbLog) << err.message;
+        }
         loadSinger(m_currentSinger);
         return;
     }
@@ -172,8 +176,10 @@ void TableModelHistorySongs::saveSong(const QString &singerName, const QString &
     query.bindValue(":historySinger", historySingerId);
     query.bindValue(":datetime", QDateTime::currentDateTime());
     query.exec();
-    if (auto error = query.lastError(); error.type() != QSqlError::NoError)
-        m_logger->error("{} DB error: {}", m_loggingPrefix, error.text());
+    if (auto error = query.lastError(); error.type() != QSqlError::NoError) {
+        auto err = okj::Error::fromSqlError(error);
+        qCWarning(dbLog) << err.message;
+    }
     loadSinger(m_currentSinger);
 }
 

--- a/src/result.h
+++ b/src/result.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <optional>
+#include <utility>
+#include "error.h"
+
+namespace okj {
+
+template <typename T>
+class Result {
+public:
+    static Result ok(T value) {
+        Result r;
+        r.m_value = std::move(value);
+        return r;
+    }
+
+    static Result err(Error error) {
+        Result r;
+        r.m_error = std::move(error);
+        return r;
+    }
+
+    bool has_value() const { return m_error.code == ErrorCode::None; }
+    const T &value() const { return *m_value; }
+    const Error &error() const { return m_error; }
+
+private:
+    std::optional<T> m_value;
+    Error m_error;
+};
+
+} // namespace okj
+

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -5,6 +5,9 @@
 #include <QJsonObject>
 #include <QNetworkReply>
 #include <QSysInfo>
+#include "logging.h"
+#include "error.h"
+#include "result.h"
 
 
 QString UpdateChecker::getOS() const
@@ -57,7 +60,7 @@ void UpdateChecker::checkForUpdates()
 {
     if (!m_settings.checkUpdates())
         return;
-    qInfo() << "Requesting current version info for branch: " << channel;
+    qCInfo(netLog) << "Requesting current version info for branch:" << channel;
     connect(manager, &QNetworkAccessManager::finished, this, &UpdateChecker::onNetworkReply);
     [[maybe_unused]]QNetworkReply *reply = manager->get(QNetworkRequest(QUrl("http://openkj.org/downloads/" + OS + "-" + channel + "-curversion.txt")));
 //    while (!reply->isFinished())
@@ -65,22 +68,28 @@ void UpdateChecker::checkForUpdates()
 //    qInfo() << "Request completed";
 }
 
+static okj::Result<QString> parseVersionReply(QNetworkReply *reply) {
+    if (reply->error() != QNetworkReply::NoError) {
+        return okj::Result<QString>::err(okj::Error::fromNetworkError(reply->error(), reply->errorString()));
+    }
+    QString version = QString(reply->readAll()).trimmed();
+    return okj::Result<QString>::ok(version);
+}
+
 void UpdateChecker::onNetworkReply(QNetworkReply *reply)
 {
-    qInfo() << "Received network reply";
-    if (reply->error() != QNetworkReply::NoError)
-    {
-        qInfo() << reply->errorString();
-        //output some meaningful error msg
+    qCInfo(netLog) << "Received network reply";
+    auto result = parseVersionReply(reply);
+    if (!result.has_value()) {
+        qCWarning(netLog) << result.error().message;
         return;
     }
-    availVersion = QString(reply->readAll());
-    availVersion = availVersion.trimmed();
+    availVersion = result.value();
     QStringList curVersionParts = currentVer.split(".");
     QStringList availVersionParts = availVersion.split(".");
     if (availVersionParts.size() != 3 || curVersionParts.size() != 3)
     {
-        qInfo() << "Got invalid version info from server";
+        qCWarning(netLog) << "Got invalid version info from server";
         return;
     }
     int availMajor = availVersionParts.at(0).toInt();
@@ -95,7 +104,7 @@ void UpdateChecker::onNetworkReply(QNetworkReply *reply)
         emit newVersionAvailable(availVersion);
     else if (availMajor == curMajor && availMinor == curMinor && availRevis > curRevis)
         emit newVersionAvailable(availVersion);
-    qInfo() << "Received version: " << availVersion << " Current version: " << currentVer;
+    qCInfo(netLog) << "Received version:" << availVersion << "Current version:" << currentVer;
     reply->deleteLater();
     disconnect(manager, &QNetworkAccessManager::finished, this, &UpdateChecker::onNetworkReply);
 
@@ -117,7 +126,7 @@ void UpdateChecker::onNetworkReply(QNetworkReply *reply)
 
 void UpdateChecker::aOnNetworkReply(QNetworkReply *reply)
 {
-    qInfo() << reply->readAll();
+    qCInfo(netLog) << reply->readAll();
     reply->deleteLater();
 }
 


### PR DESCRIPTION
## Summary
- Introduce central `Error` and `Result` types to standardize error propagation
- Wrap Qt network and SQL errors into structured objects and log via `QLoggingCategory`
- Initialize rotating async spdlog backend and forward Qt logs with `qInstallMessageHandler`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_68ac1c3238388330acef1d661c7f1989